### PR TITLE
Replace `safe_mode` by `safe_prompt`

### DIFF
--- a/lib/mistral_rb.rb
+++ b/lib/mistral_rb.rb
@@ -20,7 +20,7 @@ class MistralAPI
     self.class.base_uri base_uri
   end
 
-  def create_chat_completion(model:, messages:, temperature: 0.7, top_p: 1, max_tokens: nil, stream: false, safe_mode: false, random_seed: nil)
+  def create_chat_completion(model:, messages:, temperature: 0.7, top_p: 1, max_tokens: nil, stream: false, safe_prompt: false, random_seed: nil)
     body = {
       model: model,
       messages: messages,
@@ -28,7 +28,7 @@ class MistralAPI
       top_p: top_p,
       max_tokens: max_tokens,
       stream: stream,
-      safe_mode: safe_mode,
+      safe_prompt: safe_prompt,
       random_seed: random_seed
     }.compact.to_json
 


### PR DESCRIPTION
`safe_mode` attribute seems to have been replaced by `safe_prompt` in the last Mistral API version which results in a crash response:

```
API Error: 422 - {"object":"error","message":"{\"detail\":[{\"type\":\"extra_forbidden\",\"loc\":[\"body\",\"safe_mode\"],\"msg\":\"Extra inputs are not permitted\",\"input\":false,\"url\":\"https://errors.pydantic.dev/2.5/v/extra_forbidden\"}]}","type":"internal_error_proxy","param":null,"code":"1000"}
```

Replacing by `safe_prompt` fix the issue.

<img width="731" alt="Capture d’écran 2024-01-12 à 10 27 20" src="https://github.com/fsndzomga/mistral_rb/assets/5428510/eabbba36-aee3-4ded-94ec-38428be756e4">


Co-Authored-By @unplugandplay